### PR TITLE
do not link input and output names, use the same convention as MIDAS for histograms

### DIFF
--- a/his2h5.py
+++ b/his2h5.py
@@ -1,25 +1,28 @@
+#!/bin/env python3
 # usage: python3 his2root.py run03642.HIS
+
 import os,sys
 import h5py
 import numpy as np
 
 from readerHIS import openHIS
 
-def main():
-    if len(sys.argv) < 2:
-        print('syntax: ' + sys.argv[0] + ' <his file>')
+def main(args,options):
+    if len(args) < 1:
+        print('syntax: python3 his2root.py <his file> [options]')
         sys.exit(1)
 
-    his_file = sys.argv[1]
+    his_file = args[0]
     stem, _ = os.path.splitext(his_file)
+    outname =  stem if not options.outfile else options.outfile
     his = openHIS(his_file)
     for idx, section in enumerate(his):
-        h5_file = stem + ('-%04d.h5' % idx)
-
+        h5_file = outname + ('-%04d.h5' % idx)
+        if options.maxEntries>-1 and idx>=options.maxEntries: 
+            break
         if os.path.exists(h5_file):
             print('Refusing to write to ' + h5_file + ': file exists')
             sys.exit(1)
-
         print("transferring image ",idx)
         h5 = h5py.File(h5_file,'w')
         dset = h5.create_dataset("Image", section.shape, 'i')
@@ -29,6 +32,11 @@ def main():
         h5.close()
 
 if __name__ == '__main__':
-    main()
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog file.his [options] ')
+    parser.add_option('-o',  '--outfile'    , dest='outfile'   , type="string", default=None, help='if given, assign this name to the ROOT output file (default is inputname.root)');
+    parser.add_option('-m',  '--max-entries', dest='maxEntries', type=int     , default=-1,   help='if given, process only the first given images');
+    (options, args) = parser.parse_args()
 
-# vim:sw=4:sts=4:et
+    main(args,options)
+

--- a/his2root.py
+++ b/his2root.py
@@ -1,4 +1,6 @@
+#!/bin/env python3
 # usage: python3 his2root.py run03642.HIS
+
 import os,sys
 import h5py
 import numpy as np 
@@ -7,20 +9,28 @@ from root_numpy import array2hist
 
 from readerHIS import openHIS
 
-def main():
-    if len(sys.argv) < 2:
-        print('syntax: ' + sys.argv[0] + ' <his file>')
+def main(args,options):
+    if len(args) < 1:
+        print('syntax: python3 his2root.py <his file> [options]')
         sys.exit(1)
 
-    his_file = sys.argv[1]
+    his_file = args[0]
     stem, _ = os.path.splitext(his_file)
     his = openHIS(his_file)
-    rf = ROOT.TFile(stem+'.root','recreate')
+    outname = stem+'.root' if not options.outfile else options.outfile
+    rf = ROOT.TFile(outname,'recreate')
+
+    runN = stem.split('run')[-1]
+    run = runN if len(runN) else 'XXXX'
 
     for idx, section in enumerate(his):
+        if options.maxEntries>-1 and idx>=options.maxEntries: 
+            break
         print("transferring image ",idx)
         (nx,ny) = section.shape 
         title = stem + ('_%04d' % idx)
+        postfix = 'run{run}_ev{ev}'.format(run=run,ev=idx)
+        title = 'pic_{pfx}'.format(pfx=postfix)
         h2 = ROOT.TH2S(title,title,nx,0,nx,ny,0,ny)
         h2.GetXaxis().SetTitle('x')
         h2.GetYaxis().SetTitle('y')
@@ -29,6 +39,10 @@ def main():
     rf.Close()
 
 if __name__ == '__main__':
-    main()
+    from optparse import OptionParser
+    parser = OptionParser(usage='%prog file.his [options] ')
+    parser.add_option('-o',  '--outfile'    , dest='outfile'   , type="string", default=None, help='if given, assign this name to the ROOT output file (default is inputname.root)');
+    parser.add_option('-m',  '--max-entries', dest='maxEntries', type=int     , default=-1,   help='if given, process only the first given images');
+    (options, args) = parser.parse_args()
 
-# vim:sw=4:sts=4:et
+    main(args,options)


### PR DESCRIPTION
New Usage:

`./his2root.py run03642.HIS -m 5 -o myoutfile.root`

The new options are:

    parser.add_option('-o',  '--outfile'    , dest='outfile'   , type="string", default=None, help='if given, assign this name to the ROOT output file (default is inputname.root)');
    parser.add_option('-m',  '--max-entries', dest='maxEntries', type=int     , default=-1,   help='if given, process only the first given images');

@gmazzitelli @davidepinci 

